### PR TITLE
Add timestamp getter function to flight loop

### DIFF
--- a/Software/main/main.cpp
+++ b/Software/main/main.cpp
@@ -8,6 +8,7 @@
 #include <data/datapacket.h>
 #include <sensors/ads1115.h>
 #include <sensors/lsm6ds33.h>
+#include <utils/utils.h>
 
 #define DEBUG true
 
@@ -21,7 +22,8 @@ int main() {
     // TODO: Initialize DataPackets
     spartan::MasterDataPacket mdp;
     dataPackets[0] = new spartan::IMUDataPacket;
-
+    // std::cout << sensors.size();
+    // std::cout << dataPackets.size();
     // Initialization of sensors
     for (int i = 0; i < sensors.size(); i++) {
 	    sensors[i]->powerOn();
@@ -32,6 +34,7 @@ int main() {
     // TODO: flight loop
     for (int count  = 0; count < 100; count++) {
         for (int i = 0; i < sensors.size(); i++) {
+            mdp.timestamp = spartan::getTimeMillis();
             if (sensors[i]->poll(mdp) != spartan::RESULT_SUCCESS) {
                 std::cerr << "Sensor name: " << sensors[i]->name() << " instance; " << sensors[i]->getInstance()
                     << " poll data error!" << std::endl;

--- a/Software/main/main.cpp
+++ b/Software/main/main.cpp
@@ -22,8 +22,7 @@ int main() {
     // TODO: Initialize DataPackets
     spartan::MasterDataPacket mdp;
     dataPackets[0] = new spartan::IMUDataPacket;
-    // std::cout << sensors.size();
-    // std::cout << dataPackets.size();
+
     // Initialization of sensors
     for (int i = 0; i < sensors.size(); i++) {
 	    sensors[i]->powerOn();

--- a/Software/spartan/CMakeLists.txt
+++ b/Software/spartan/CMakeLists.txt
@@ -24,6 +24,9 @@ add_library(
     ./src/sensors/lsm6ds33.h
     ./src/sensors/lsm6ds33.cpp
     ./src/globals.h
+
+    ./src/utils/utils.h
+    ./src/utils/utils.cpp
 )
 
 target_include_directories(spartanflightlib PUBLIC ${mraa_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}/src")


### PR DESCRIPTION
Closes #23 

- Adds src/utils/utils.h and src/utils/utils.cpp to spartanflightlib static library.

- Flight loop now properly includes timestamps