### PR TITLE
Part of #22: Create MTK3339(GPS) skeleton class 

### DIFF
--- a/Software/main/main.cpp
+++ b/Software/main/main.cpp
@@ -8,16 +8,19 @@
 #include <data/datapacket.h>
 #include <sensors/ads1115.h>
 #include <sensors/lsm6ds33.h>
+#include <sensors/mtk3339.h>
+
 #include <utils/utils.h>
 
 #define DEBUG true
 
 int main() {
     std::array<spartan::PacketType*, 1> dataPackets;
-    std::array<spartan::Sensor*, 1> sensors;
+    std::array<spartan::Sensor*, 2> sensors;
 
     // TODO: Initialize Sensors
     sensors[0] = new spartan::LSM6DS33(1, 0);
+    sensors[1] = new spartan::MTK3339(1, 1);
 
     // TODO: Initialize DataPackets
     spartan::MasterDataPacket mdp;

--- a/Software/spartan/CMakeLists.txt
+++ b/Software/spartan/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(
     ./src/sensors/ads1115.cpp
     ./src/sensors/lsm6ds33.h
     ./src/sensors/lsm6ds33.cpp
+    ./src/sensors/mtk3339.h
+    ./src/sensors/mtk3339.cpp
     ./src/globals.h
 
     ./src/utils/utils.h

--- a/Software/spartan/src/sensors/mtk3339.cpp
+++ b/Software/spartan/src/sensors/mtk3339.cpp
@@ -1,0 +1,28 @@
+#include "mtk3339.h"
+
+// Constructor
+
+spartan::MTK3339::MTK3339(int bus, uint8_t address)
+    : Sensor(bus, address), m_i2c(bus, true)
+{}
+
+// Identification
+
+const char* spartan::MTK3339::name() const 
+{
+    const char * str = "MTK3339";
+    return str;
+};
+
+void spartan::MTK3339::printSensorInfo() {}
+
+
+// Power functions
+
+int spartan::MTK3339::powerOn() { return 0; }
+int spartan::MTK3339::powerOff() { return 0; }
+
+// Update sensor data buffer
+int spartan::MTK3339::poll(MasterDataPacket &dp) { return 0; }
+
+int spartan::MTK3339::printValues() const { return 0; }

--- a/Software/spartan/src/sensors/mtk3339.h
+++ b/Software/spartan/src/sensors/mtk3339.h
@@ -1,0 +1,36 @@
+#ifndef MTK3339_H_INCLUDED
+#define MTK3339_H_INCLUDED
+
+// TODO: When Apple releases an ARM Macbook, fix this again
+#if !defined(__x86_64__) && !defined(_WIN32)
+#include <mraa/i2c.hpp>
+#else
+#include <mock/i2c.h>
+#endif
+
+#include <stdint.h>
+#include <sensors/sensor.h>
+
+namespace spartan
+{
+    class MTK3339 : public Sensor {
+    public:
+        MTK3339(int bus, uint8_t address);
+
+        // Identification
+        virtual const char * name() const;
+        virtual void printSensorInfo();
+
+        // Sensor control
+        virtual int powerOn();
+        virtual int powerOff();
+        virtual int poll(MasterDataPacket &dp);
+
+        // Debugging & printing
+        virtual int printValues() const;
+    private:
+        mraa::I2c m_i2c;
+    };
+} // namespace spartan
+
+#endif // MTK3339_H_INCLUDED


### PR DESCRIPTION
Overview
-----

This PR implements part of #22.
It does the following: 

- Create skeleton for MTK3339 class (mtk3339.cpp & mtk3339.h)
- Initialize MTK3339 sensor in main/main.cpp
- Include files (mtk3339.cpp & mtk3339.h) in main/spartan/CMakeLists.txt
