### PR TITLE
Rename `Sensor` class's `poll` function to `pollData`

### DIFF
--- a/Software/main/main.cpp
+++ b/Software/main/main.cpp
@@ -34,7 +34,7 @@ int main() {
     for (int count  = 0; count < 100; count++) {
         for (int i = 0; i < sensors.size(); i++) {
             mdp.timestamp = spartan::getTimeMillis();
-            if (sensors[i]->poll(mdp) != spartan::RESULT_SUCCESS) {
+            if (sensors[i]->pollData(mdp) != spartan::RESULT_SUCCESS) {
                 std::cerr << "Sensor name: " << sensors[i]->name() << " instance; " << sensors[i]->getInstance()
                     << " poll data error!" << std::endl;
             }

--- a/Software/spartan/src/sensors/ads1115.cpp
+++ b/Software/spartan/src/sensors/ads1115.cpp
@@ -2,7 +2,7 @@
 /*
 spartan::ADS1115::ADS1115(int bus, uint8_t address) {}
 
-bool spartan::ADS1115::pollData(spartan::DataPacket &dp) { return 0; }
+int spartan::ADS1115::pollData(spartan::DataPacket &dp) { return 0; }
 
 void spartan::ADS1115::printValues() const {}
 */

--- a/Software/spartan/src/sensors/ads1115.h
+++ b/Software/spartan/src/sensors/ads1115.h
@@ -16,7 +16,7 @@ namespace spartan
     class ADS1115 : public Sensor {
     public:
         ADS1115(int bus, uint8_t address);
-        virtual bool pollData(spartan::MasterDataPacket &dp);
+        virtual int pollData(spartan::MasterDataPacket &dp);
         virtual int printValues() const;
     };
 } // namespace spartan

--- a/Software/spartan/src/sensors/lsm6ds33.cpp
+++ b/Software/spartan/src/sensors/lsm6ds33.cpp
@@ -247,7 +247,7 @@ void spartan::LSM6DS33::printRawValues() {
 
 // Override sensor base class functions
 
-int spartan::LSM6DS33::poll(MasterDataPacket &dp) {
+int spartan::LSM6DS33::pollData(MasterDataPacket &dp) {
     if (!update())
         return RESULT_FALSE;
     dp.temp = (float) ((m_temp / 16) + m_offsets._temp_offset);

--- a/Software/spartan/src/sensors/lsm6ds33.h
+++ b/Software/spartan/src/sensors/lsm6ds33.h
@@ -171,7 +171,7 @@ namespace spartan {
         virtual int powerOn();
         virtual int powerOff();
 
-        virtual int poll(MasterDataPacket &dp);
+        virtual int pollData(MasterDataPacket &dp);
         // returns RESULT_FALSE if no new data, RESULT_SUCCESS if member data was updated with latest reading,
         // ERROR in the case of an error
         int hasNewData();
@@ -184,7 +184,7 @@ namespace spartan {
         bool updateSettings(lsm6Settings settings);
 
         //virtual bool longPoll() { return false; /*dummy*/}
-        // call poll() over a longer period of time, averaging out the values (maybe allow time input functionality, or
+        // call pollData() over a longer period of time, averaging out the values (maybe allow time input functionality, or
         // just do poll 10 times and average out the values, storing result into rawAccel array)
         // "poll","read","get"; reads raw data from sensor and returns it; maybe into a file? or an input stream? or a
         // member variable of the class/struct? and then preprocess function can pull from that?

--- a/Software/spartan/src/sensors/sensor.h
+++ b/Software/spartan/src/sensors/sensor.h
@@ -20,7 +20,7 @@ namespace spartan {
         // Standard sensor implementation
         virtual int powerOn() = 0;
         virtual int powerOff() = 0;
-        virtual int poll(MasterDataPacket &dp) = 0;
+        virtual int pollData(MasterDataPacket &dp) = 0;
 
         // Debug options
         virtual int printValues() const = 0;


### PR DESCRIPTION
Closes #48 

- Rename the sensor class' poll function to pollData wherever it is declared, defined, used, or inherited. 
- Changes the prototype pollData function in the ADS1115 class to return int instead of bool. 