### PR TITLE
Improve build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,11 @@ The SPARTAN sensor driver library builds itself primarily on Intel's [MRAA libra
 
 ## Building
 
-To build the SPARTAN FSW, run the following shell script:
+To build the SPARTAN FSW, run the `make` command with either the `default` target or no target as follows:
 
 ```shell
-./build.sh
+make
 ```
-
-**TODO: Will be better implemented. We should add more dedicated Makefile that invokes CMake, with targets for: build (default), test, Valgrind/gdb, etc.**
 
 ## High-level Overview of Code Base
 

--- a/Software/CMakeLists.txt
+++ b/Software/CMakeLists.txt
@@ -3,6 +3,8 @@ project(SPARTAN_Flight_Software)
 
 set (CMAKE_CXX_STANDARD 20)
 
+add_compile_options(-Wall -Wextra -Werror)
+
 # TODO: When Apple releases an ARM Macbook, fix this again
 if ((${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     OR (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "AMD64"))

--- a/Software/Makefile
+++ b/Software/Makefile
@@ -22,4 +22,4 @@ test: standard-build
 clean:
 	rm -rf $(BUILD_DIRECTORY)
 
-.PHONY: build clean
+.PHONY: default standard-build build run lint test clean

--- a/Software/Makefile
+++ b/Software/Makefile
@@ -1,0 +1,25 @@
+default: standard-build
+
+BUILD_DIRECTORY := "_build"
+
+# Added to avoid verbose printing of "entering/leaving directory" outputted messages
+standard-build:
+	make build --no-print-directory
+
+build:
+	cmake -B $(BUILD_DIRECTORY)
+	cmake --build $(BUILD_DIRECTORY)
+
+run: standard-build
+	./"$(BUILD_DIRECTORY)"/main/spartan
+
+lint: standard-build
+	# TODO: Add linting scripts
+
+test: standard-build
+	# TODO: Add testing infrastructure (could also include Valgrind/gdb testing as well)
+
+clean:
+	rm -rf $(BUILD_DIRECTORY)
+
+.PHONY: build clean

--- a/Software/build.sh
+++ b/Software/build.sh
@@ -1,8 +1,0 @@
-FILE=./_build/main/spartan
-if [ -f "$FILE" ]; then
-    rm -rf $FILE
-fi
-cmake -B _build
-cd _build
-cmake --build .
-./main/spartan

--- a/Software/main/main.cpp
+++ b/Software/main/main.cpp
@@ -24,7 +24,7 @@ int main() {
     dataPackets[0] = new spartan::IMUDataPacket;
 
     // Initialization of sensors
-    for (int i = 0; i < sensors.size(); i++) {
+    for (size_t i = 0; i < sensors.size(); i++) {
 	    sensors[i]->powerOn();
     }
     std::ofstream fout;
@@ -32,14 +32,14 @@ int main() {
 
     // TODO: flight loop
     for (int count  = 0; count < 100; count++) {
-        for (int i = 0; i < sensors.size(); i++) {
+        for (size_t i = 0; i < sensors.size(); i++) {
             mdp.timestamp = spartan::getTimeMillis();
             if (sensors[i]->pollData(mdp) != spartan::RESULT_SUCCESS) {
                 std::cerr << "Sensor name: " << sensors[i]->name() << " instance; " << sensors[i]->getInstance()
                     << " poll data error!" << std::endl;
             }
         }
-        for (int i = 0; i < dataPackets.size(); i++) {
+        for (size_t i = 0; i < dataPackets.size(); i++) {
             dataPackets[i]->populate(mdp);
             if (DEBUG) {
                 std::cout << "Packet size " << dataPackets[i]->getSize() << std::endl;

--- a/Software/mock/i2c.cpp
+++ b/Software/mock/i2c.cpp
@@ -2,17 +2,28 @@
 
 // Contructors/destructors
 
-mraa::I2c::I2c(int bus, bool raw) {}
-mraa::I2c::I2c(void* i2c_context) {}
+mraa::I2c::I2c(int bus, bool raw) {
+    (void) bus;
+    (void) raw;
+}
+
+mraa::I2c::I2c(void* i2c_context) {
+    (void) i2c_context;
+}
+
 mraa::I2c::~I2c() {}
 
 // I2C interface settings
 
 mraa::Result mraa::I2c::frequency(mraa::I2cMode mode) {
+    (void) mode;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::I2c::address(uint8_t address) {
+    (void) address;
+
     return mraa::SUCCESS;
 }
 
@@ -30,14 +41,20 @@ int mraa::I2c::read(uint8_t* data, int length) {
 }
 
 uint8_t mraa::I2c::readReg(uint8_t reg) {
+    (void) reg;
+
     return (uint8_t) std::rand();
 }
 
 uint16_t mraa::I2c::readWordReg(uint8_t reg) {
+    (void) reg;
+
     return (uint16_t) std::rand();
 }
 
 int mraa::I2c::readBytesReg(uint8_t reg, uint8_t* data, int length) {
+    (void) reg;
+
     for (int i = 0; i < length; i++) {
         data[i] = (uint8_t) std::rand();
     }
@@ -47,17 +64,27 @@ int mraa::I2c::readBytesReg(uint8_t reg, uint8_t* data, int length) {
 // Write functions
 
 mraa::Result mraa::I2c::writeByte(uint8_t data) {
+    (void) data;
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::I2c::write(const uint8_t* data, int length) {
+    (void) data;
+    (void) length;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::I2c::writeReg(uint8_t reg, uint8_t data) {
+    (void) reg;
+    (void) data;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::I2c::writeWordReg(uint8_t reg, uint16_t data) {
+    (void) reg;
+    (void) data;
+
     return mraa::SUCCESS;
 }

--- a/Software/mock/spi.cpp
+++ b/Software/mock/spi.cpp
@@ -2,40 +2,64 @@
 
 // Constructors/destructors
 
-mraa::Spi::Spi(int bus) {}
-mraa::Spi::Spi(int bus, int cs) {}
-mraa::Spi::Spi(void* spi_context) {}
+mraa::Spi::Spi(int bus) {
+    (void) bus;
+}
+
+mraa::Spi::Spi(int bus, int cs) {
+    (void) bus;
+    (void) cs;
+}
+
+mraa::Spi::Spi(void* spi_context) {
+    (void) spi_context;
+}
+
 mraa::Spi::~Spi(){}
 
 // SPI interface settings
 
 mraa::Result mraa::Spi::mode(Spi_Mode mode) {
+    (void) mode;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Spi::frequency(int hz) {
+    (void) hz;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Spi::lsbmode(bool lsb) {
+    (void) lsb;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Spi::bitPerWord(unsigned int bits) {
+    (void) bits;
+
     return mraa::SUCCESS;
 }
 
 // Read/write functions
 
 int mraa::Spi::writeByte(uint8_t data) {
+    (void) data;
+
     return std::rand();
 }
 
 int mraa::Spi::writeWord(uint16_t data) {
+    (void) data;
+
     return std::rand();
 }
 
 uint8_t* mraa::Spi::write(uint8_t* txBuf, int length) {
+    (void) txBuf;
+
     uint8_t *buf = (uint8_t *)std::malloc(length * sizeof(uint8_t));
     if (buf == NULL) {
         throw std::bad_alloc();
@@ -48,6 +72,8 @@ uint8_t* mraa::Spi::write(uint8_t* txBuf, int length) {
 }
 
 uint16_t* mraa::Spi::writeWord(uint16_t* txBuf, int length) {
+    (void) txBuf;
+
     uint16_t *buf = (uint16_t *)std::malloc(length * sizeof(uint16_t));
     if (buf == NULL) {
         throw std::bad_alloc();
@@ -60,6 +86,8 @@ uint16_t* mraa::Spi::writeWord(uint16_t* txBuf, int length) {
 }
 
 mraa::Result mraa::Spi::transfer(uint8_t* txBuf, uint8_t* rxBuf, int length) {
+    (void) txBuf;
+
     for (int i = 0; i < length; i++) {
         rxBuf[i] = (uint8_t) std::rand();
     }
@@ -67,6 +95,8 @@ mraa::Result mraa::Spi::transfer(uint8_t* txBuf, uint8_t* rxBuf, int length) {
 }
 
 mraa::Result mraa::Spi::transfer_word(uint16_t* txBuf, uint16_t* rxBuf, int length) {
+    (void) txBuf;
+
     for (int i = 0; i < length; i++) {
         rxBuf[i] = (uint16_t) std::rand();
     }

--- a/Software/mock/uart.cpp
+++ b/Software/mock/uart.cpp
@@ -2,9 +2,18 @@
 
 // Constructors/destructors
 
-mraa::Uart::Uart(int uart) {}
-mraa::Uart::Uart(std::string path) {}
-mraa::Uart::Uart(void* uart_context) {}
+mraa::Uart::Uart(int uart) {
+    (void) uart;
+}
+
+mraa::Uart::Uart(std::string path) {
+    (void) path;
+}
+
+mraa::Uart::Uart(void* uart_context) {
+    (void) uart_context;
+}
+
 mraa::Uart::~Uart() {}
 
 // UART interface settings
@@ -16,10 +25,15 @@ std::string mraa::Uart::getDevicePath() {
 // Read/write functions
 
 int mraa::Uart::read(char* data, int length) {
+    (void) data;
+    (void) length;
+
     return std::rand();
 }
 
 int mraa::Uart::write(const char* data, int length) {
+    (void) data;
+
     return length;
 }
 
@@ -45,6 +59,8 @@ int mraa::Uart::writeStr(std::string data) {
 // Miscellaneous data functions
 
 bool mraa::Uart::dataAvailable(unsigned int millis) {
+    (void) millis;
+
     return true;
 }
 
@@ -53,25 +69,42 @@ mraa::Result mraa::Uart::flush() {
 }
 
 mraa::Result mraa::Uart::sendBreak(int duration) {
+    (void) duration;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Uart::setBaudRate(unsigned int baud) {
+    (void) baud;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Uart::setMode(int bytesize, UartParity parity, int stopbits) {
+    (void) bytesize;
+    (void) parity;
+    (void) stopbits;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Uart::setFlowcontrol(bool xonxoff, bool rtscts) {
+    (void) xonxoff;
+    (void) rtscts;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Uart::setTimeout(int read, int write, int interchar) {
+    (void) read;
+    (void) write;
+    (void) interchar;
+
     return mraa::SUCCESS;
 }
 
 mraa::Result mraa::Uart::setNonBlocking(bool nonblock) {
+    (void) nonblock;
+
     return mraa::SUCCESS;
 }

--- a/Software/src/sensors/lsm6ds33.cpp
+++ b/Software/src/sensors/lsm6ds33.cpp
@@ -163,9 +163,10 @@ int spartan::LSM6DS33::powerOff() {
 
 // Polling functions
 
+// TODO(harrisoncassar): Update this `update` function to utilize `ERROR_*` enums defined in `globals.h`
 bool spartan::LSM6DS33::update() {
     if (m_status == STATUS_OFF)
-        return ERROR_INVALID_STATUS;
+        return false; // Should be returning ERROR_INVALID_STATUS
 
     if (hasNewData() == RESULT_FALSE)
         //std::cerr << "No new data" << std::endl;

--- a/Software/src/sensors/sensor.h
+++ b/Software/src/sensors/sensor.h
@@ -33,8 +33,8 @@ namespace spartan {
         virtual int getStatus() const;
 
     protected:
-        int m_status;
         int m_busID;
+        int m_status;
         int m_instance; // support for multiple sensors of same type
     };
 } // namespace spartan


### PR DESCRIPTION
Closes #35.

Replaces the entry-point for building/compiling SPARTAN from a static bash script to a more robust and more easily-usable and modifiable `Makefile`. This is better, and allows support of more build-related functionalities down the road (including system tests and linting scripts).

TODO before merging:
- [x] Update `master` README accordingly.
- [x] Force all compilation warnings as errors.