### PR TITLE
Simple refactoring

### DIFF
--- a/Software/src/datapacket/datapacket.h
+++ b/Software/src/datapacket/datapacket.h
@@ -16,9 +16,9 @@ namespace spartan {
 
     class IMUDataPacket : public PacketType {
     public:
-        virtual int getSize() const;
-        virtual std::string format() const;
-        virtual void populate(const MasterDataPacket &dp);
+        int getSize() const override;
+        std::string format() const override;
+        void populate(const MasterDataPacket &dp) override;
     private:
         float m_accel_x;
         float m_accel_y;
@@ -31,8 +31,8 @@ namespace spartan {
 
     class AltimeterDataPacket : public PacketType {
     public:
-        virtual int getSize() const;
-        virtual void populate(const MasterDataPacket &dp);
+        int getSize() const override;
+        void populate(const MasterDataPacket &dp) override;
     private:
         float m_pressure;
         float m_baro_altitude;
@@ -40,8 +40,8 @@ namespace spartan {
 
     class GPSDataPacket : public PacketType {
     public:
-        virtual int getSize() const;
-        virtual void populate(const MasterDataPacket &dp);
+        int getSize() const override;
+        void populate(const MasterDataPacket &dp) override;
     private:
         float m_latitude;
         float m_longitude;
@@ -50,8 +50,8 @@ namespace spartan {
 
     class AVNHealthPacket : public PacketType {
     public:
-        virtual int getSize() const;
-        virtual void populate(const MasterDataPacket &dp);
+        int getSize() const override;
+        void populate(const MasterDataPacket &dp) override;
     private:
         float m_voltage_AVN;
         float m_IMU1_current;
@@ -63,8 +63,8 @@ namespace spartan {
 
     class FCHealthPacket : public PacketType {
     public:
-        virtual int getSize() const;
-        virtual void populate(const MasterDataPacket &dp);
+        int getSize() const override;
+        void populate(const MasterDataPacket &dp) override;
     private:
         float m_FC_voltage;
         float m_FC_current;
@@ -72,8 +72,8 @@ namespace spartan {
 
     class RadioHealthPacket : public PacketType {
     public:
-        virtual int getSize() const;
-        virtual void populate(const MasterDataPacket &dp);
+        int getSize() const override;
+        void populate(const MasterDataPacket &dp) override;
     private:
         float m_radio_voltage;
         float m_radio_current;
@@ -81,8 +81,8 @@ namespace spartan {
 
     class PayloadHealthPacket : public PacketType {
     public:
-        virtual int getSize() const;
-        virtual void populate(const MasterDataPacket &dp);
+        int getSize() const override;
+        void populate(const MasterDataPacket &dp) override;
     private:
         float m_payload_voltage;
         float m_payload_current;

--- a/Software/src/sensors/ads1115.h
+++ b/Software/src/sensors/ads1115.h
@@ -16,8 +16,8 @@ namespace spartan
     class ADS1115 : public Sensor {
     public:
         ADS1115(int bus, uint8_t address);
-        virtual int pollData(spartan::MasterDataPacket &dp);
-        virtual int printValues() const;
+        int pollData(spartan::MasterDataPacket &dp) override;
+        int printValues() const override;
     };
 } // namespace spartan
 

--- a/Software/src/sensors/lsm6ds33.cpp
+++ b/Software/src/sensors/lsm6ds33.cpp
@@ -26,26 +26,30 @@ bool spartan::LSM6DS33::writeReg(uint8_t* buffer, unsigned short size) {
     mraa::Result msg = m_i2c.write(buffer, size);
 
     // Error handling
-    if (msg == mraa::SUCCESS)
-        return true;
-    else if (msg == mraa::ERROR_INVALID_PARAMETER)
-        std::cerr << "Invalid parameter." << std::endl;
-    else if (msg == mraa::ERROR_INVALID_HANDLE)
-        std::cerr << "ERROR_INVALID_HANDLE" << std::endl;
-    else if (msg == mraa::ERROR_NO_RESOURCES)
-        std::cerr << "ERROR_NO_RESOURCES" << std::endl;
-    else if (msg == mraa::ERROR_INVALID_RESOURCE)
-        std::cerr << "ERROR_INVALID_RESOURCE" << std::endl;
-    else if (msg == mraa::ERROR_INVALID_QUEUE_TYPE)
-        std::cerr << "ERROR_INVALID_QUEUE_TYPE" << std::endl;
-    else if (msg == mraa::ERROR_NO_DATA_AVAILABLE)
-        std::cerr << "ERROR_NO_DATA_AVAILABLE" << std::endl;
-    else if (msg == mraa::ERROR_INVALID_PLATFORM)
-        std::cerr << "ERROR_INVALID_PLATFORM" << std::endl;
-    else if (msg == mraa::ERROR_PLATFORM_NOT_INITIALISED)
-        std::cerr << "ERROR_PLATFORM_NOT_INITIALISED" << std::endl;
-    else if (msg == mraa::ERROR_UNSPECIFIED)
-        std::cerr << "ERROR_UNSPECIFIED" << std::endl;
+    
+    switch (msg) {
+    case mraa::SUCCESS:
+        return true; break;
+    case mraa::ERROR_INVALID_PARAMETER:
+        std::cerr << "Invalid parameter." << std::endl; break;
+    case mraa::ERROR_INVALID_HANDLE:
+        std::cerr << "ERROR_INVALID_HANDLE" << std::endl; break;
+    case mraa::ERROR_NO_RESOURCES:
+        std::cerr << "ERROR_NO_RESOURCES" << std::endl; break;
+    case mraa::ERROR_INVALID_RESOURCE:
+        std::cerr << "ERROR_INVALID_RESOURCE" << std::endl; break;
+    case mraa::ERROR_INVALID_QUEUE_TYPE:
+        std::cerr << "ERROR_INVALID_QUEUE_TYPE" << std::endl; break;
+    case mraa::ERROR_NO_DATA_AVAILABLE:
+        std::cerr << "ERROR_NO_DATA_AVAILABLE" << std::endl; break;
+    case mraa::ERROR_INVALID_PLATFORM:
+        std::cerr << "ERROR_INVALID_PLATFORM" << std::endl; break;
+    case mraa::ERROR_PLATFORM_NOT_INITIALISED:
+        std::cerr << "ERROR_PLATFORM_NOT_INITIALISED" << std::endl; break;
+    case mraa::ERROR_UNSPECIFIED:
+        std::cerr << "ERROR_UNSPECIFIED" << std::endl; break;
+    default: break;
+    }   
 
     return false;
 }

--- a/Software/src/sensors/lsm6ds33.cpp
+++ b/Software/src/sensors/lsm6ds33.cpp
@@ -28,27 +28,37 @@ bool spartan::LSM6DS33::writeReg(uint8_t* buffer, unsigned short size) {
     // Error handling
     
     switch (msg) {
-    case mraa::SUCCESS:
-        return true; break;
-    case mraa::ERROR_INVALID_PARAMETER:
-        std::cerr << "Invalid parameter." << std::endl; break;
-    case mraa::ERROR_INVALID_HANDLE:
-        std::cerr << "ERROR_INVALID_HANDLE" << std::endl; break;
-    case mraa::ERROR_NO_RESOURCES:
-        std::cerr << "ERROR_NO_RESOURCES" << std::endl; break;
-    case mraa::ERROR_INVALID_RESOURCE:
-        std::cerr << "ERROR_INVALID_RESOURCE" << std::endl; break;
-    case mraa::ERROR_INVALID_QUEUE_TYPE:
-        std::cerr << "ERROR_INVALID_QUEUE_TYPE" << std::endl; break;
-    case mraa::ERROR_NO_DATA_AVAILABLE:
-        std::cerr << "ERROR_NO_DATA_AVAILABLE" << std::endl; break;
-    case mraa::ERROR_INVALID_PLATFORM:
-        std::cerr << "ERROR_INVALID_PLATFORM" << std::endl; break;
-    case mraa::ERROR_PLATFORM_NOT_INITIALISED:
-        std::cerr << "ERROR_PLATFORM_NOT_INITIALISED" << std::endl; break;
-    case mraa::ERROR_UNSPECIFIED:
-        std::cerr << "ERROR_UNSPECIFIED" << std::endl; break;
-    default: break;
+        case mraa::SUCCESS:
+            return true;
+        case mraa::ERROR_INVALID_PARAMETER:
+            std::cerr << "Invalid parameter." << std::endl; 
+            break;
+        case mraa::ERROR_INVALID_HANDLE:
+            std::cerr << "ERROR_INVALID_HANDLE" << std::endl; 
+            break;
+        case mraa::ERROR_NO_RESOURCES:
+            std::cerr << "ERROR_NO_RESOURCES" << std::endl; 
+            break;
+        case mraa::ERROR_INVALID_RESOURCE:
+            std::cerr << "ERROR_INVALID_RESOURCE" << std::endl; 
+            break;
+        case mraa::ERROR_INVALID_QUEUE_TYPE:
+            std::cerr << "ERROR_INVALID_QUEUE_TYPE" << std::endl; 
+            break;
+        case mraa::ERROR_NO_DATA_AVAILABLE:
+            std::cerr << "ERROR_NO_DATA_AVAILABLE" << std::endl; 
+            break;
+        case mraa::ERROR_INVALID_PLATFORM:
+            std::cerr << "ERROR_INVALID_PLATFORM" << std::endl; 
+            break;
+        case mraa::ERROR_PLATFORM_NOT_INITIALISED:
+            std::cerr << "ERROR_PLATFORM_NOT_INITIALISED" << std::endl; 
+            break;
+        case mraa::ERROR_UNSPECIFIED:
+            std::cerr << "ERROR_UNSPECIFIED" << std::endl; 
+            break;
+        default: 
+            break;
     }   
 
     return false;
@@ -58,18 +68,36 @@ bool spartan::LSM6DS33::writeReg(uint8_t* buffer, unsigned short size) {
 
 void spartan::LSM6DS33::setMultipliers() {
     switch (m_settings.accelRange) {
-        case lsm6ds33::_2g: _accel_multiplier = accel_multiplier[0]; break;
-        case lsm6ds33::_4g: _accel_multiplier = accel_multiplier[1]; break;
-        case lsm6ds33::_8g: _accel_multiplier = accel_multiplier[2]; break;
-        case lsm6ds33::_16g: _accel_multiplier = accel_multiplier[3]; break;
+        case lsm6ds33::_2g: 
+            _accel_multiplier = accel_multiplier[0]; 
+            break;
+        case lsm6ds33::_4g: 
+            _accel_multiplier = accel_multiplier[1]; 
+            break;
+        case lsm6ds33::_8g: 
+            _accel_multiplier = accel_multiplier[2]; 
+            break;
+        case lsm6ds33::_16g: 
+            _accel_multiplier = accel_multiplier[3]; 
+            break;
     }
 
     switch (m_settings.gyroRange) {
-        case lsm6ds33::_125dps: _gyro_multiplier = gyro_multiplier[0]; break;
-        case lsm6ds33::_250dps: _gyro_multiplier = gyro_multiplier[1]; break;
-        case lsm6ds33::_500dps: _gyro_multiplier = gyro_multiplier[2]; break;
-        case lsm6ds33::_1000dps: _gyro_multiplier = gyro_multiplier[3]; break;
-        case lsm6ds33::_2000dps: _gyro_multiplier = gyro_multiplier[3]; break;
+        case lsm6ds33::_125dps: 
+            _gyro_multiplier = gyro_multiplier[0]; 
+            break;
+        case lsm6ds33::_250dps: 
+            _gyro_multiplier = gyro_multiplier[1]; 
+            break;
+        case lsm6ds33::_500dps: 
+            _gyro_multiplier = gyro_multiplier[2]; 
+            break;
+        case lsm6ds33::_1000dps: 
+            _gyro_multiplier = gyro_multiplier[3]; 
+            break;
+        case lsm6ds33::_2000dps: 
+            _gyro_multiplier = gyro_multiplier[3]; 
+            break;
     }
 }
 

--- a/Software/src/sensors/lsm6ds33.h
+++ b/Software/src/sensors/lsm6ds33.h
@@ -168,10 +168,10 @@ namespace spartan {
         LSM6DS33(int busID, int lsm6ID, lsm6Settings settings);
         LSM6DS33(int busID, int lsm6ID);
 
-        virtual int powerOn();
-        virtual int powerOff();
+        int powerOn() override;
+        int powerOff() override;
 
-        virtual int pollData(MasterDataPacket &dp);
+        int pollData(MasterDataPacket &dp) override;
         // returns RESULT_FALSE if no new data, RESULT_SUCCESS if member data was updated with latest reading,
         // ERROR in the case of an error
         int hasNewData();
@@ -190,7 +190,7 @@ namespace spartan {
         // member variable of the class/struct? and then preprocess function can pull from that?
         // rawData type is a placeholder for now; will return raw sensor data
 
-        virtual void printSensorInfo();
+        void printSensorInfo() override;
         void printRawValues();
 
         const float accel_multiplier[4] = {0.061, 0.122, 0.244, 0.488};
@@ -198,8 +198,8 @@ namespace spartan {
         const float gyro_multiplier[5] = {4.375, 8.75, 17.5, 35, 70};
         float _gyro_multiplier;
 
-        virtual int printValues() const;
-        virtual const char * name() const;
+        int printValues() const override;
+        const char * name() const override;
 
     private:
         short m_temp;


### PR DESCRIPTION
Closes #54 

1. Changed "virtual" to "override" in overridden methods for sub-classes under the "PacketType" and "Sensor" classes.
2.  Changed if/else block to a switch block in the spartan::LSM6DS33::writeReg method. I couldn't find any other huge if/else blocks that required changing.