### PR TITLE
Improve return values of `LSM6DS33` class's methods by utilizing global error codes

### DIFF
--- a/Software/src/globals.h
+++ b/Software/src/globals.h
@@ -77,7 +77,6 @@ namespace spartan {
         ERROR_READ,
         ERROR_POLL,
         ERROR_INVALID_STATUS,
-        ERROR_NO_NEW_DATA
     };
 
     // sensor status types

--- a/Software/src/globals.h
+++ b/Software/src/globals.h
@@ -64,7 +64,7 @@ namespace spartan {
         // maybe this as a general status for being mission ready before launch? (this would be right after turn-on)
         IDLE,
         READY_TO_RECIEVE,
-        READY_TO_SEND,
+        READY_TO_SEND
     };
 
     // return codes (success and error types)
@@ -77,6 +77,8 @@ namespace spartan {
         ERROR_READ,
         ERROR_POLL,
         ERROR_INVALID_STATUS,
+        ERROR_WRITE,
+        ERROR_UPDATE_SETTING
     };
 
     // sensor status types

--- a/Software/src/globals.h
+++ b/Software/src/globals.h
@@ -76,7 +76,8 @@ namespace spartan {
         ERROR_DATAFORMAT,
         ERROR_READ,
         ERROR_POLL,
-        ERROR_INVALID_STATUS
+        ERROR_INVALID_STATUS,
+        ERROR_NO_NEW_DATA
     };
 
     // sensor status types

--- a/Software/src/sensors/lsm6ds33.cpp
+++ b/Software/src/sensors/lsm6ds33.cpp
@@ -152,7 +152,7 @@ int spartan::LSM6DS33::powerOn() {
     }
 
     //run first update of sensor
-    if (update() == false) {
+    if (update() != RESULT_SUCCESS) {
         std::cerr << "Unable to initial poll LSM6DS33." << std::endl;
         return ERROR_POLL;
     }
@@ -200,9 +200,10 @@ int spartan::LSM6DS33::update() {
     if (m_status == STATUS_OFF)
         return ERROR_INVALID_STATUS; // Should be returning ERROR_INVALID_STATUS
 
-    if (hasNewData() == RESULT_FALSE)
-        //std::cerr << "No new data" << std::endl;
-        return ERROR_NO_NEW_DATA;
+    if (hasNewData() == RESULT_FALSE) {
+        std::cerr << "No new data" << std::endl;
+        return RESULT_FALSE;
+    }
 
     // set I2C address
     if (m_i2c.address(lsm6Address) != mraa::SUCCESS) {
@@ -229,7 +230,7 @@ int spartan::LSM6DS33::update() {
     m_accel.y = ((m_buffer[11] << 8) | m_buffer[10]);
     m_accel.z = ((m_buffer[13] << 8) | m_buffer[12]);
 
-    return true;
+    return RESULT_SUCCESS;
 }
 
 int spartan::LSM6DS33::hasNewData() {
@@ -281,7 +282,7 @@ void spartan::LSM6DS33::printRawValues() {
 // Override sensor base class functions
 
 int spartan::LSM6DS33::pollData(MasterDataPacket &dp) {
-    if (!update())
+    if (update() != RESULT_SUCCESS)
         return RESULT_FALSE;
     dp.temp = (float) ((m_temp / 16) + m_offsets._temp_offset);
     dp.accel_x = (float) ((m_accel.x*_accel_multiplier) + m_offsets._accel_offsets.x);

--- a/Software/src/sensors/lsm6ds33.cpp
+++ b/Software/src/sensors/lsm6ds33.cpp
@@ -196,24 +196,24 @@ int spartan::LSM6DS33::powerOff() {
 // Polling functions
 
 // TODO(harrisoncassar): Update this `update` function to utilize `ERROR_*` enums defined in `globals.h`
-bool spartan::LSM6DS33::update() {
+int spartan::LSM6DS33::update() {
     if (m_status == STATUS_OFF)
-        return false; // Should be returning ERROR_INVALID_STATUS
+        return ERROR_INVALID_STATUS; // Should be returning ERROR_INVALID_STATUS
 
     if (hasNewData() == RESULT_FALSE)
         //std::cerr << "No new data" << std::endl;
-        return false;
+        return ERROR_NO_NEW_DATA;
 
     // set I2C address
     if (m_i2c.address(lsm6Address) != mraa::SUCCESS) {
         std::cerr << "Unable to set I2C address." << std::endl;
-        return false;
+        return ERROR_ADDR;
     }
 
     // read temp,x,y,z (14 bytes) into buffer
     if (m_i2c.readBytesReg(lsm6ds33::OUT_TEMP_L, m_buffer, lsm6ds33::BUFFER_SIZE) == -1) {
         std::cerr << "Unable to read data bytes starting from LSM6DS33_OUT_TEMP_L." << std::endl;
-        return false;
+        return ERROR_READ;
     }
 
     //record rawacceleration values using data reads for x,y,z respectively

--- a/Software/src/sensors/lsm6ds33.h
+++ b/Software/src/sensors/lsm6ds33.h
@@ -174,8 +174,8 @@ namespace spartan {
         int pollData(MasterDataPacket &dp) override;
         // returns RESULT_FALSE if no new data, RESULT_SUCCESS if member data was updated with latest reading,
         // ERROR in the case of an error
-        int hasNewData();
-        virtual bool update();
+        int hasNewData();   
+        virtual int update();
 
         bool writeReg(uint8_t* buffer, unsigned short size);
 

--- a/Software/src/sensors/lsm6ds33.h
+++ b/Software/src/sensors/lsm6ds33.h
@@ -174,14 +174,14 @@ namespace spartan {
         int pollData(MasterDataPacket &dp) override;
         // returns RESULT_FALSE if no new data, RESULT_SUCCESS if member data was updated with latest reading,
         // ERROR in the case of an error
-        int hasNewData();   
+        int hasNewData();
         virtual int update();
 
-        bool writeReg(uint8_t* buffer, unsigned short size);
+        int writeReg(uint8_t* buffer, unsigned short size);
 
         void setMultipliers();
-        bool updateSettings();
-        bool updateSettings(lsm6Settings settings);
+        int updateSettings();
+        int updateSettings(lsm6Settings settings);
 
         //virtual bool longPoll() { return false; /*dummy*/}
         // call pollData() over a longer period of time, averaging out the values (maybe allow time input functionality, or


### PR DESCRIPTION
Closes #57 

Changed update() method in `src/sensors/lsm6ds33.cpp` to return error codes defined in `src/globals.h`

1. Changed function type of update() from bool to int
2. Added new error code `ERROR_NO_NEW_DATA` to `globals.h`